### PR TITLE
Enable to store images in local machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,11 @@
 
 # Ignore all logfiles and tempfiles.
 /log/*
+/public/uploads/*
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+!/public/uploads/.keep
 
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*

--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -9,6 +9,19 @@ class CatsController < ApplicationController
     render json: cats
   end
 
+  def create
+    name = params[:file].original_filename
+
+    name = "#{rand(1000..9999)}_#{name}"
+
+    path = File.join("public", "uploads", name)
+    File.open(path, "wb") { |f| f.write(params[:file].read) }
+
+    Cat.create(image: "http://localhost:3000/uploads/#{name}")
+
+    render json: { url: "http://localhost:3000/uploads/#{name}" }
+  end
+
   def categories
     categories = Cat.categories
     render json: categories


### PR DESCRIPTION
Set up create action in Cat controller
* to store uploaded images in local machine(hid by .gitignore)
* to generate URLs for the uploaded image
* to create a Cat model using the assigned URL
* generate endpoints to see the created cat model